### PR TITLE
Special case for ServiceDiscovery

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -126,8 +126,12 @@
 			return el.id === serviceId;
 		});
 
-		if (filteredRO.length < 1)
+		if (filteredRO.length < 1) {
+			if (serviceTyp === 'ServiceDiscovery') {
+				return receiverObjs[0];
+			}
 			return undefined;
+		}
 
 		return filteredRO[0];
 	}


### PR DESCRIPTION
getServiceWithTypeAndId needs to return the ServiceDiscovery, which is a
special case since it has no service id.

Jira-issue: WP-699
