### PR TITLE
add internal webinos event listeners to services

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -110,7 +110,7 @@
 	 */
 	Registry.prototype.getRegisteredObjectsMap = function() {
 		return this.objects;
-	}
+	};
 
 	/**
 	 * Get service matching type and id.
@@ -134,7 +134,28 @@
 		}
 
 		return filteredRO[0];
-	}
+	};
+
+	Registry.prototype.emitEvent = function(event) {
+		var that = this;
+		Object.keys(this.objects).forEach(function(serviceTyp) {
+			if (!that.objects[serviceTyp]) return;
+
+			that.objects[serviceTyp].forEach(function(service) {
+				if (!service.listeners) return;
+				if (!service.listeners[event.name]) return;
+
+				service.listeners[event.name].forEach(function(listener) {
+					try {
+						listener(event);
+					} catch(e) {
+						console.log('service event listener error:');
+						console.log(e);
+					};
+				});
+			});
+		});
+	};
 
 	// Export definitions for node.js
 	if (typeof module !== 'undefined'){

--- a/lib/rpc.js
+++ b/lib/rpc.js
@@ -482,6 +482,7 @@
 	 * @param obj Object with fields describing the service.
 	 */
 	var RPCWebinosService = function (obj) {
+		this.listeners = {};
 		if (!obj) {
 			this.id = '';
 			this.api = '';
@@ -509,6 +510,20 @@
 			description: this.description,
 			serviceAddress: this.serviceAddress
 		};
+	};
+
+	RPCWebinosService.prototype._addListener = function (event, listener) {
+		if (!event || !listener) throw new Error('missing event or listener');
+
+		if (!this.listeners[event]) this.listeners[event] = [];
+		this.listeners[event].push(listener);
+	};
+
+	RPCWebinosService.prototype._removeListener = function (event, listener) {
+		if (!event || !listener) return;
+		this.listeners[event].forEach(function(l, i) {
+			if (l === listener) this.listeners[event][i] = null;
+		});
 	};
 
 	/**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webinos-jsonrpc2"
-, "version": "0.8.0-3"
+, "version": "0.8.1"
 , "description": "JSON-RPC 2 implementation used be they webinos project."
 , "keywords": ["webinos", "JSON-RPC 2", "json", "rpc"]
 , "homepage": "http://www.webinos.org"


### PR DESCRIPTION
services can now add listeners to internal webinos events. Inside a service
call _addListener(event, listener). This will be used to deliver the
'disconnect' event, when webinos entities disconnect.

Jira-issue: http://jira.webinos.org/browse/WP-851
