### PR TITLE
Fix bug with handleResponse

### DIFF
--- a/lib/rpc.js
+++ b/lib/rpc.js
@@ -258,7 +258,7 @@
 		if (this.awaitingResponse[response.id]) {
 			var waitResp = this.awaitingResponse[response.id];
 
-			if (waitResp.onResult && response.result) {
+			if (waitResp.onResult && typeof response.result !== "undefined") {
 				waitResp.onResult(response.result);
 				logger.log("RPC called scb for response");
 			}


### PR DESCRIPTION
If the success callback accepts a single boolean parameter and it is set to 'false', the callback isn't called. Use typeof to determine if the result is specified.
