### PR TITLE
Wp 1044 remove servicedisco dashboard references

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -127,9 +127,6 @@
 		});
 
 		if (filteredRO.length < 1) {
-			if (/ServiceDiscovery|Dashboard/.test(serviceTyp)) {
-				return receiverObjs[0];
-			}
 			return undefined;
 		}
 

--- a/lib/rpc.js
+++ b/lib/rpc.js
@@ -177,7 +177,7 @@
 			} else {
 				serviceId = serviceIdRest;
 			}
-		} else if (!/ServiceDiscovery|Dashboard/.test(service)) {
+		} else {
 			// request to object registered with registerCallbackObject
 			isCallbackObject = true;
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webinos-jsonrpc2"
-, "version": "0.8.5"
+, "version": "0.8.6"
 , "description": "The JSON-RPC 2 implementation used by the webinos project."
 , "keywords": ["webinos", "JSON-RPC 2", "json", "rpc"]
 , "homepage": "http://www.webinos.org"


### PR DESCRIPTION
Remove references to ServiceDiscovery and Dashboard

No longer needed as both APIs now use standard API URL service types.

Jira-issue: http://jira.webinos.org/browse/WP-1044
